### PR TITLE
feat: add Attachment support with colored sidebars

### DIFF
--- a/slack-messaging/src/attachment.rs
+++ b/slack-messaging/src/attachment.rs
@@ -1,0 +1,127 @@
+use crate::blocks::Block;
+use crate::validators::*;
+
+use serde::Serialize;
+use slack_messaging_derive::Builder;
+
+/// [Legacy Slack attachment](https://api.slack.com/reference/messaging/attachments)
+/// with support for colored sidebars and Block Kit content.
+///
+/// Attachments are the only way to render a colored sidebar in Slack messages.
+/// They sit alongside (not inside) the `blocks` array at the message root level.
+///
+/// # Example
+///
+/// ```
+/// use slack_messaging::mrkdwn;
+/// use slack_messaging::{Message, Attachment};
+/// use slack_messaging::blocks::Section;
+/// # use std::error::Error;
+///
+/// # fn try_main() -> Result<(), Box<dyn Error>> {
+/// let message = Message::builder()
+///     .attachment(
+///         Attachment::builder()
+///             .color("#e74c3c")
+///             .block(
+///                 Section::builder()
+///                     .text(mrkdwn!("Critical finding detected")?)
+///                     .build()?
+///             )
+///             .build()?
+///     )
+///     .build()?;
+///
+/// let expected = serde_json::json!({
+///     "attachments": [
+///         {
+///             "color": "#e74c3c",
+///             "blocks": [
+///                 {
+///                     "type": "section",
+///                     "text": {
+///                         "type": "mrkdwn",
+///                         "text": "Critical finding detected"
+///                     }
+///                 }
+///             ]
+///         }
+///     ]
+/// });
+///
+/// let json = serde_json::to_value(message)?;
+///
+/// assert_eq!(json, expected);
+/// #     Ok(())
+/// # }
+/// # fn main() {
+/// #     try_main().unwrap()
+/// # }
+/// ```
+#[derive(Debug, Clone, Serialize, PartialEq, Builder)]
+pub struct Attachment {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) color: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(push_item = "block", validate("list::max_item_50"))]
+    pub(crate) blocks: Option<Vec<Block>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) fallback: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocks::test_helpers::*;
+
+    #[test]
+    fn it_implements_builder() {
+        let expected = Attachment {
+            color: Some("#e74c3c".into()),
+            blocks: Some(vec![section("hello world").into()]),
+            fallback: Some("hello world".into()),
+        };
+
+        let val = Attachment::builder()
+            .color("#e74c3c")
+            .blocks(vec![section("hello world").into()])
+            .fallback("hello world")
+            .build()
+            .unwrap();
+
+        assert_eq!(val, expected);
+    }
+
+    #[test]
+    fn it_implements_push_item_method() {
+        let expected = Attachment {
+            color: Some("#2ecc71".into()),
+            blocks: Some(vec![
+                header("title").into(),
+                section("content").into(),
+            ]),
+            fallback: None,
+        };
+
+        let val = Attachment::builder()
+            .color("#2ecc71")
+            .block(header("title"))
+            .block(section("content"))
+            .build()
+            .unwrap();
+
+        assert_eq!(val, expected);
+    }
+
+    #[test]
+    fn it_skips_none_fields() {
+        let val = Attachment::builder().color("#f39c12").build().unwrap();
+        let json = serde_json::to_value(val).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({ "color": "#f39c12" })
+        );
+    }
+}

--- a/slack-messaging/src/lib.rs
+++ b/slack-messaging/src/lib.rs
@@ -10,8 +10,10 @@ pub mod composition_objects;
 /// Error types used in this crate.
 pub mod errors;
 
+mod attachment;
 mod message;
 mod validators;
 mod value;
 
+pub use attachment::{Attachment, AttachmentBuilder};
 pub use message::{Message, MessageBuilder};

--- a/slack-messaging/src/message.rs
+++ b/slack-messaging/src/message.rs
@@ -1,3 +1,4 @@
+use crate::attachment::Attachment;
 use crate::blocks::Block;
 use crate::validators::*;
 
@@ -143,6 +144,10 @@ pub struct Message {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) reply_broadcast: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(push_item = "attachment", validate("list::max_item_20"))]
+    pub(crate) attachments: Option<Vec<Attachment>>,
 }
 
 #[cfg(test)]
@@ -165,6 +170,7 @@ mod tests {
             replace_original: Some(true),
             delete_original: Some(true),
             reply_broadcast: Some(true),
+            attachments: None,
         };
 
         let val = Message::builder()
@@ -216,6 +222,7 @@ mod tests {
             replace_original: None,
             delete_original: None,
             reply_broadcast: None,
+            attachments: None,
         };
 
         let val = Message::builder()


### PR DESCRIPTION
## Summary
- Adds `Attachment` struct with `color`, `blocks`, and `fallback` fields
- Adds `attachments` field to `Message` with `push_item` builder support and `max_item_20` validation
- Validates attachment blocks with `max_item_50` to match Slack's per-attachment block limit
- Follows existing crate patterns: `Builder` derive, `serde` skip, `validators`

This enables colored sidebar rendering in Slack webhook messages — the only mechanism Slack provides for message-level color accents.